### PR TITLE
Add automatically generated change log file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,341 @@
+# Change Log
+
+## [Unreleased](https://github.com/hsz/idea-gitignore/tree/HEAD)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v1.0.2...HEAD)
+
+**Fixed bugs:**
+
+- There is item "Add to null" in context menu [\#96](https://github.com/hsz/idea-gitignore/issues/96)
+
+- Dialog doesn't close on enter, while renaming typescript file. \(shift F6\) [\#93](https://github.com/hsz/idea-gitignore/issues/93)
+
+- ConcurrentModificationException in v1.0 [\#84](https://github.com/hsz/idea-gitignore/issues/84)
+
+**Closed issues:**
+
+- add to null [\#101](https://github.com/hsz/idea-gitignore/issues/101)
+
+- New file .idea/dataSources.local.xml [\#97](https://github.com/hsz/idea-gitignore/issues/97)
+
+- ConcurrentModificationException [\#92](https://github.com/hsz/idea-gitignore/issues/92)
+
+- v1.0: "Cover entry" inspection and non-existing folders [\#88](https://github.com/hsz/idea-gitignore/issues/88)
+
+**Merged pull requests:**
+
+- Update README.md [\#90](https://github.com/hsz/idea-gitignore/pull/90) ([mathben](https://github.com/mathben))
+
+## [v1.0.2](https://github.com/hsz/idea-gitignore/tree/v1.0.2) (2015-03-04)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v1.0.1...v1.0.2)
+
+**Closed issues:**
+
+- V1.0.1 [\#89](https://github.com/hsz/idea-gitignore/issues/89)
+
+## [v1.0.1](https://github.com/hsz/idea-gitignore/tree/v1.0.1) (2015-03-03)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v1.0...v1.0.1)
+
+**Closed issues:**
+
+- Null Exception Intellij 14 [\#86](https://github.com/hsz/idea-gitignore/issues/86)
+
+- Monotone version control support [\#83](https://github.com/hsz/idea-gitignore/issues/83)
+
+- .hgignore should never consider 'syntax: glob' as "never used" [\#82](https://github.com/hsz/idea-gitignore/issues/82)
+
+- Add "file ignored color" [\#79](https://github.com/hsz/idea-gitignore/issues/79)
+
+## [v1.0](https://github.com/hsz/idea-gitignore/tree/v1.0) (2015-03-01)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.9...v1.0)
+
+**Implemented enhancements:**
+
+- Show Ignored Files dialog sorting is weird [\#40](https://github.com/hsz/idea-gitignore/issues/40)
+
+**Closed issues:**
+
+- Mercurial regexp support \(.hgignore file\) [\#77](https://github.com/hsz/idea-gitignore/issues/77)
+
+- Darcs support \(.boring file\) [\#76](https://github.com/hsz/idea-gitignore/issues/76)
+
+- Feature request: chefignore support [\#75](https://github.com/hsz/idea-gitignore/issues/75)
+
+- Add listing of the program of MySQLWorkbench [\#74](https://github.com/hsz/idea-gitignore/issues/74)
+
+- Idea 14 freezing after right click in \*.gitignore [\#73](https://github.com/hsz/idea-gitignore/issues/73)
+
+- "Show ignored files" is buggy [\#38](https://github.com/hsz/idea-gitignore/issues/38)
+
+**Merged pull requests:**
+
+- Added WebStorm to the list of supported JetBrains IDE. [\#80](https://github.com/hsz/idea-gitignore/pull/80) ([VanDalkvist](https://github.com/VanDalkvist))
+
+- Revert "Added WebStorm to the list of supported JetBrains IDE." [\#81](https://github.com/hsz/idea-gitignore/pull/81) ([hsz](https://github.com/hsz))
+
+## [v0.9](https://github.com/hsz/idea-gitignore/tree/v0.9) (2015-02-19)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.8.1...v0.9)
+
+**Closed issues:**
+
+- Move "Ignore files support" settings to VCS section [\#70](https://github.com/hsz/idea-gitignore/issues/70)
+
+## [v0.8.1](https://github.com/hsz/idea-gitignore/tree/v0.8.1) (2015-02-04)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.8...v0.8.1)
+
+**Implemented enhancements:**
+
+- Use official Git icon/logo [\#65](https://github.com/hsz/idea-gitignore/issues/65)
+
+- Retina-ready Icon [\#63](https://github.com/hsz/idea-gitignore/issues/63)
+
+**Closed issues:**
+
+- WebStorm / intelliJ files to ignore [\#72](https://github.com/hsz/idea-gitignore/issues/72)
+
+- NoSuchMethodError in IntelliJ Idea 12 [\#71](https://github.com/hsz/idea-gitignore/issues/71)
+
+- .dockerignore support [\#58](https://github.com/hsz/idea-gitignore/issues/58)
+
+- .npmignore support [\#57](https://github.com/hsz/idea-gitignore/issues/57)
+
+## [v0.8](https://github.com/hsz/idea-gitignore/tree/v0.8) (2014-12-22)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.7...v0.8)
+
+**Implemented enhancements:**
+
+- IDE \(PhpStorm\) does not recognize path started by dot in gitignore file [\#66](https://github.com/hsz/idea-gitignore/issues/66)
+
+**Fixed bugs:**
+
+- Add template... on External Libraries [\#68](https://github.com/hsz/idea-gitignore/issues/68)
+
+- error on clicking ".gitignore template" [\#67](https://github.com/hsz/idea-gitignore/issues/67)
+
+- Exception when closing a project [\#64](https://github.com/hsz/idea-gitignore/issues/64)
+
+- renaming project root directory cause IllegalArgumentException [\#49](https://github.com/hsz/idea-gitignore/issues/49)
+
+**Closed issues:**
+
+- Other donation options [\#60](https://github.com/hsz/idea-gitignore/issues/60)
+
+- Custom ignore templates [\#53](https://github.com/hsz/idea-gitignore/issues/53)
+
+**Merged pull requests:**
+
+- .hgignore .npmignore .docker support [\#69](https://github.com/hsz/idea-gitignore/pull/69) ([hsz](https://github.com/hsz))
+
+## [v0.7](https://github.com/hsz/idea-gitignore/tree/v0.7) (2014-11-17)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.6.1...v0.7)
+
+**Fixed bugs:**
+
+- Receiving JDOM exception after update to 0.6.1 [\#61](https://github.com/hsz/idea-gitignore/issues/61)
+
+**Closed issues:**
+
+- Donate to each editor window [\#59](https://github.com/hsz/idea-gitignore/issues/59)
+
+**Merged pull requests:**
+
+- Set donationShown variable to an empty string to avoid JDOM error. [\#62](https://github.com/hsz/idea-gitignore/pull/62) ([danpfe](https://github.com/danpfe))
+
+## [v0.6.1](https://github.com/hsz/idea-gitignore/tree/v0.6.1) (2014-11-13)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.6...v0.6.1)
+
+**Closed issues:**
+
+- Make suggestion to add .gitignore file optional [\#18](https://github.com/hsz/idea-gitignore/issues/18)
+
+## [v0.6](https://github.com/hsz/idea-gitignore/tree/v0.6) (2014-11-12)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.5.4...v0.6)
+
+**Fixed bugs:**
+
+- Cannot create file '/my\_project/.gitignore'. File already exists. [\#55](https://github.com/hsz/idea-gitignore/issues/55)
+
+- The version-0.5.4 find new error [\#51](https://github.com/hsz/idea-gitignore/issues/51)
+
+- PHPStorm reports an error. [\#50](https://github.com/hsz/idea-gitignore/issues/50)
+
+**Closed issues:**
+
+- Donation link on plugin description is not working [\#56](https://github.com/hsz/idea-gitignore/issues/56)
+
+- Add more than one template [\#54](https://github.com/hsz/idea-gitignore/issues/54)
+
+- Files/folders marked as ignored in IntelliJ's project are shown as 'never used' in the .gitignore file [\#47](https://github.com/hsz/idea-gitignore/issues/47)
+
+- No search input by default [\#27](https://github.com/hsz/idea-gitignore/issues/27)
+
+## [v0.5.4](https://github.com/hsz/idea-gitignore/tree/v0.5.4) (2014-08-15)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.5.3...v0.5.4)
+
+**Closed issues:**
+
+- Plugin exception error [\#48](https://github.com/hsz/idea-gitignore/issues/48)
+
+- Support for tables [\#46](https://github.com/hsz/idea-gitignore/issues/46)
+
+- Support for fenced code blocks [\#45](https://github.com/hsz/idea-gitignore/issues/45)
+
+## [v0.5.3](https://github.com/hsz/idea-gitignore/tree/v0.5.3) (2014-08-11)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.5.2...v0.5.3)
+
+**Closed issues:**
+
+- update failed for AnAction with ID=Gitignore.IgnoreGroup [\#43](https://github.com/hsz/idea-gitignore/issues/43)
+
+- NPE in mobi.hsz.idea.gitignore.util.Utils.getSuitableGitignoreFiles\(Utils.java:81\) [\#42](https://github.com/hsz/idea-gitignore/issues/42)
+
+- Exception when use [\#41](https://github.com/hsz/idea-gitignore/issues/41)
+
+- NoSuchMethodError: FileReferenceHelper.getPsiFileSystemItem [\#39](https://github.com/hsz/idea-gitignore/issues/39)
+
+**Merged pull requests:**
+
+- Travis [\#44](https://github.com/hsz/idea-gitignore/pull/44) ([hsz](https://github.com/hsz))
+
+## [v0.5.2](https://github.com/hsz/idea-gitignore/tree/v0.5.2) (2014-07-28)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.5.1...v0.5.2)
+
+**Closed issues:**
+
+- ClassCastException: mobi.hsz.idea.gitignore.psi.impl.GitignoreEntryFileImpl cannot be cast to com.intellij.psi.impl.source.tree.LeafPsiElement [\#37](https://github.com/hsz/idea-gitignore/issues/37)
+
+- Version 0.5.1 corrupts right click on project [\#36](https://github.com/hsz/idea-gitignore/issues/36)
+
+- update failed for AnAction with ID=Gitignore.IgnoreGroup [\#35](https://github.com/hsz/idea-gitignore/issues/35)
+
+## [v0.5.1](https://github.com/hsz/idea-gitignore/tree/v0.5.1) (2014-07-27)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.5...v0.5.1)
+
+**Closed issues:**
+
+- Null Pointer Exception [\#34](https://github.com/hsz/idea-gitignore/issues/34)
+
+- NoSuchMethod Error  [\#33](https://github.com/hsz/idea-gitignore/issues/33)
+
+- update failed for AnAction with ID=Gitignore.IgnoreGroup [\#32](https://github.com/hsz/idea-gitignore/issues/32)
+
+- IDE Fatal Errors - IDEA 13.1.4 - OS X 10.8.5 [\#30](https://github.com/hsz/idea-gitignore/issues/30)
+
+- Files/directories marked as never used [\#26](https://github.com/hsz/idea-gitignore/issues/26)
+
+**Merged pull requests:**
+
+- Support build.xml on Windows [\#31](https://github.com/hsz/idea-gitignore/pull/31) ([bedla](https://github.com/bedla))
+
+- Negation resolving fix [\#29](https://github.com/hsz/idea-gitignore/pull/29) ([zolotov](https://github.com/zolotov))
+
+- Resolving fix [\#28](https://github.com/hsz/idea-gitignore/pull/28) ([zolotov](https://github.com/zolotov))
+
+## [v0.5](https://github.com/hsz/idea-gitignore/tree/v0.5) (2014-07-25)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.4...v0.5)
+
+**Implemented enhancements:**
+
+- Respect cursor end-of-line setting [\#12](https://github.com/hsz/idea-gitignore/issues/12)
+
+- Directories classified as files [\#8](https://github.com/hsz/idea-gitignore/issues/8)
+
+**Closed issues:**
+
+- Prevent adding duplicate entries [\#17](https://github.com/hsz/idea-gitignore/issues/17)
+
+**Merged pull requests:**
+
+- Cleanup inspections [\#25](https://github.com/hsz/idea-gitignore/pull/25) ([zolotov](https://github.com/zolotov))
+
+- Cleanup [\#24](https://github.com/hsz/idea-gitignore/pull/24) ([zolotov](https://github.com/zolotov))
+
+- Add extra info to README [\#23](https://github.com/hsz/idea-gitignore/pull/23) ([zolotov](https://github.com/zolotov))
+
+- Compile pattern before checking [\#22](https://github.com/hsz/idea-gitignore/pull/22) ([zolotov](https://github.com/zolotov))
+
+- Reimplement generator dialog [\#21](https://github.com/hsz/idea-gitignore/pull/21) ([zolotov](https://github.com/zolotov))
+
+- Completion/resolving/rename refactoring [\#20](https://github.com/hsz/idea-gitignore/pull/20) ([zolotov](https://github.com/zolotov))
+
+- Glob parser, Cover entry inspection [\#19](https://github.com/hsz/idea-gitignore/pull/19) ([hsz](https://github.com/hsz))
+
+## [v0.4](https://github.com/hsz/idea-gitignore/tree/v0.4) (2014-07-08)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.3.3...v0.4)
+
+**Fixed bugs:**
+
+- Loading project error [\#14](https://github.com/hsz/idea-gitignore/issues/14)
+
+- Error with the OSX template [\#13](https://github.com/hsz/idea-gitignore/issues/13)
+
+**Closed issues:**
+
+- Exclamation mark disappears after clicking on row [\#15](https://github.com/hsz/idea-gitignore/issues/15)
+
+**Merged pull requests:**
+
+- Show ignored files [\#16](https://github.com/hsz/idea-gitignore/pull/16) ([hsz](https://github.com/hsz))
+
+## [v0.3.3](https://github.com/hsz/idea-gitignore/tree/v0.3.3) (2014-07-03)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.3.1...v0.3.3)
+
+**Implemented enhancements:**
+
+- Any idea to add http://www.gitignore.io/ support? [\#1](https://github.com/hsz/idea-gitignore/issues/1)
+
+**Fixed bugs:**
+
+- PsiElement\(NEGATION\) java.lang.AssertionError: PsiElement\(NEGATION\) on ! [\#10](https://github.com/hsz/idea-gitignore/issues/10)
+
+- NoSuchMethodError [\#7](https://github.com/hsz/idea-gitignore/issues/7)
+
+**Closed issues:**
+
+- Usability problems [\#9](https://github.com/hsz/idea-gitignore/issues/9)
+
+**Merged pull requests:**
+
+- Missing gitignore notification [\#11](https://github.com/hsz/idea-gitignore/pull/11) ([hsz](https://github.com/hsz))
+
+- Files/directories completion in editor [\#6](https://github.com/hsz/idea-gitignore/pull/6) ([hsz](https://github.com/hsz))
+
+## [v0.3.1](https://github.com/hsz/idea-gitignore/tree/v0.3.1) (2014-06-26)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.3...v0.3.1)
+
+**Fixed bugs:**
+
+- NullPointerException after creating .gitignore file [\#5](https://github.com/hsz/idea-gitignore/issues/5)
+
+- cannot create class "mobi.hsz.idea.gitignore.actions.NewGitignoreFileAction" \[Plugin: mobi.hsz.idea.gitignore\]: cannot create class "mobi.hsz.idea.gitignore.actions.NewGitignoreFileAction" \[Plugin: mobi.hsz.idea.gitignore\] [\#2](https://github.com/hsz/idea-gitignore/issues/2)
+
+## [v0.3](https://github.com/hsz/idea-gitignore/tree/v0.3) (2014-06-25)
+
+[Full Changelog](https://github.com/hsz/idea-gitignore/compare/v0.2.2...v0.3)
+
+**Merged pull requests:**
+
+- Generator [\#3](https://github.com/hsz/idea-gitignore/pull/3) ([hsz](https://github.com/hsz))
+
+## [v0.2.2](https://github.com/hsz/idea-gitignore/tree/v0.2.2) (2014-06-24)
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*


### PR DESCRIPTION
Hi, as I can see, you are carefully fill tags and labels for issues in your repo.

For such cases I create a [github_changelog_generator](https://github.com/skywinder/github-changelog-generator), that generate change log file based on **tags**, **issues** and merged **pull requests** from :octocat: Issue Tracker.

This PR add change log file to your repo (generated by this script).
You can check, how it is look like here: [Change Log](https://github.com/skywinder/idea-gitignore/blob/add-change-log-file/CHANGELOG.md)

Some essential features, that has this script:

-  it **exclude** not-related to changelog issues (any issue, that has label `question` `duplicate` `invalid` `wontfix` )
- Distinguish issues **according labels**:
    - Merged pull requests (all `merged` pull-requests)
    - Bug fixes (by label `bug` in issue)
    - Enhancements (by label `enhancement` in issue)
    -   Issues (closed issues `w/o any labels`)
- Generate neat Change Log file according basic [change log guidelines](http://keepachangelog.com).

You can easily update this file in future by simply run script: `github_changelog_generator hsz/idea-gitignore` in your repo folder and it make your Change Log file up-to-date again!

Hope you find this commit as useful. :wink: