### PR TITLE
[Readme] Changed IDE name "0xDBE" to "DataGrip"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ files in your project. It supports following JetBrains IDEs:
 - PyCharm
 - RubyMine
 - WebStorm
-- 0xDBE
+- DataGrip
 
 *Compiled with Java 1.6*
 


### PR DESCRIPTION
JetBrains' "0xDBE" IDE was renamed to "[DataGrip](https://blog.jetbrains.com/datagrip/2015/12/16/datagrip-1-0-formerly-0xdbe-a-new-ide-for-dbs-and-sql/)".
