### PR TITLE
#367 comment out import of CacheMap for checkstyle

### DIFF
--- a/src/mobi/hsz/idea/gitignore/IgnoreManager.java
+++ b/src/mobi/hsz/idea/gitignore/IgnoreManager.java
@@ -50,7 +50,7 @@ import mobi.hsz.idea.gitignore.indexing.IgnoreEntryOccurrence;
 import mobi.hsz.idea.gitignore.indexing.IgnoreFilesIndex;
 import mobi.hsz.idea.gitignore.psi.IgnoreFile;
 import mobi.hsz.idea.gitignore.settings.IgnoreSettings;
-import mobi.hsz.idea.gitignore.util.CacheMap;
+//import mobi.hsz.idea.gitignore.util.CacheMap;
 import mobi.hsz.idea.gitignore.util.Debounced;
 import mobi.hsz.idea.gitignore.util.Utils;
 import org.jetbrains.annotations.NonNls;


### PR DESCRIPTION
Comment out the currently unused import of CacheMap to stop checkstyle from failing the build