### PR TITLE
Fix project leak via indexable set

### DIFF
--- a/src/mobi/hsz/idea/gitignore/IgnoreManager.java
+++ b/src/mobi/hsz/idea/gitignore/IgnoreManager.java
@@ -568,6 +568,7 @@ public class IgnoreManager extends AbstractProjectComponent implements DumbAware
 
     /** Disable manager. */
     private void disable() {
+        ExternalIndexableSetContributor.invalidateCache(myProject);
         virtualFileManager.removeVirtualFileListener(virtualFileListener);
         settings.removeListener(settingsListener);
 


### PR DESCRIPTION
ExternalIndexableSetContributor is an extension point. Extension points live as long as the whole application, so caching project without cleaning them up causes projects to be leaked.
<img width="873" alt="screen shot 2018-05-15 at 15 11 36" src="https://user-images.githubusercontent.com/32124/40056857-492f3560-5855-11e8-959c-5b691ca8d3b2.png">

This seems to be the most straightforward fix, however, I'd also consider caching file sets as a Project UserData value instead of keeping them in the extension point field